### PR TITLE
Add paging support to hypermedia

### DIFF
--- a/src/main/java/com/greglturnquist/springagram/GalleryRepository.java
+++ b/src/main/java/com/greglturnquist/springagram/GalleryRepository.java
@@ -1,8 +1,6 @@
 package com.greglturnquist.springagram;
 
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-@RepositoryRestResource
-public interface GalleryRepository extends CrudRepository<Gallery, Long> {
+public interface GalleryRepository extends PagingAndSortingRepository<Gallery, Long> {
 }

--- a/src/main/java/com/greglturnquist/springagram/ItemRepository.java
+++ b/src/main/java/com/greglturnquist/springagram/ItemRepository.java
@@ -2,11 +2,9 @@ package com.greglturnquist.springagram;
 
 import java.util.List;
 
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-@RepositoryRestResource()
-public interface ItemRepository extends CrudRepository<Item, Long> {
+public interface ItemRepository extends PagingAndSortingRepository<Item, Long> {
 
 	List<Item> findByGalleryIsNull();
 


### PR DESCRIPTION
Hypermedia API now has Spring Data's paging interface. This should make it easy to control volume of data being downloaded.

NOTE: Removed redundant @RepositoryRestResource annotation.
