### PR TITLE
Move configuration in index.html files to a RequireJS 'data-main' file.

### DIFF
--- a/src/main/resources/static/run.js
+++ b/src/main/resources/static/run.js
@@ -24,7 +24,8 @@ requirejs.config({
 });
 
 function isMobile () {
-	return window.sagDeviceType === 'mobile';
+	var html = document.documentElement;
+	return html.getAttribute('data-device') === 'mobile';
 }
 
 }());

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -3,7 +3,6 @@
 <head>
     <title>Spring-A-Gram :: Upload your fav pics</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <script th:inline="javascript">var sagDeviceType = 'normal';</script>
     <script data-main="run.js" src="requirejs/require.js"></script>
     <style>
         .thumbnail {

--- a/src/main/resources/templates/mobile/index.html
+++ b/src/main/resources/templates/mobile/index.html
@@ -1,9 +1,8 @@
 <!DOCTYPE HTML>
-<html>
+<html data-device="mobile">
 <head>
     <title>Spring-a-Gram</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script th:inline="javascript">var sagDeviceType = 'mobile';</script>
     <script data-main="run.js" src="requirejs/require.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Now that the configs are 99.9% the same across device types, we can consolidate them into a single file.  Unfortunately, I had to create a global variable to make this work.  If we decide to "go responsive" later and remove spring-mobile, the need for the global will go away.
