### PR TITLE
Upgrade security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,18 +16,13 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-data-releasetrain.version>Fowler-BUILD-SNAPSHOT</spring-data-releasetrain.version>
-		<spring-security.version>4.0.0.RC1</spring-security.version>
+		<spring-security.version>4.0.0.RC2</spring-security.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-rest</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-rest-webmvc</artifactId>
-			<version>2.3.0.DATAREST-463-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bump security up to 4.0.0.RC2. This is the same version for which Spring Data REST is currently tested against.

Also drop old snapshot version of SDR, since it has since been merged into Fowler-BUILD-SNAPSHOT.